### PR TITLE
Add sidebar and accessibility tweaks

### DIFF
--- a/theme/edumy/javascript/cocoon.preprocess.js
+++ b/theme/edumy/javascript/cocoon.preprocess.js
@@ -207,6 +207,16 @@ $(function() {
       $("#ccnToggleDarkMode").addClass("active");
       $("body").addClass("ccnDarkMode");
     }
+    // High contrast mode
+    $("#ccnToggleContrast").click(function() {
+      $("#ccnToggleContrast").toggleClass("active");
+      $("body").toggleClass("ccnHighContrast").css("transition", "none");
+      document.cookie = 'contrast=' + ($("#ccnToggleContrast").hasClass("active") ? 'high' : 'normal') + '; path=/;';
+    });
+    if (document.cookie.match(/contrast=high/i) != null) {
+      $("#ccnToggleContrast").addClass("active");
+      $("body").addClass("ccnHighContrast");
+    }
   });
   $(window).on('load', function() {
     $(".ccn_course_content > li.section:first-child > .ccnTopicFirstExp .panel-collapse").addClass("show");

--- a/theme/edumy/style/custom.css
+++ b/theme/edumy/style/custom.css
@@ -6,4 +6,47 @@
  *  IMPORTANT: Please remember not to override this file when updating Edumy theme. Keep a backup of this file before updating Edumy theme.
  *
  *
- */
+*/
+
+/* Simple sidebar styles */
+.simple-sidebar {
+  padding: 10px;
+}
+.simple-sidebar-menu {
+  list-style: none;
+  padding: 0;
+  margin: 0;
+}
+.simple-sidebar-menu li {
+  margin-bottom: 10px;
+}
+.simple-sidebar-menu a {
+  display: flex;
+  align-items: center;
+  color: #444;
+  text-decoration: none;
+}
+.simple-sidebar-menu a .label {
+  margin-left: 8px;
+}
+@media (max-width: 768px) {
+  .simple-sidebar {
+    display: none;
+  }
+}
+
+body.ccnDarkMode .simple-sidebar-menu a {
+  color: #fff;
+}
+
+/* High contrast mode */
+body.ccnHighContrast {
+  background-color: #000 !important;
+  color: #fff !important;
+}
+body.ccnHighContrast a {
+  color: #0ff !important;
+}
+body.ccnHighContrast .simple-sidebar-menu a {
+  color: #fff !important;
+}

--- a/theme/edumy/templates/ccn_my.mustache
+++ b/theme/edumy/templates/ccn_my.mustache
@@ -31,6 +31,7 @@
               <div class="dashbord_nav_list ccn_dashbord_nav_list">
                 {{> theme_boost/flat_navigation2 }}
               </div>
+              {{> theme_edumy/custom_sidebar }}
             {{/dashboard_nav_flat}}
             <div class="pl30 pr30">
               {{{ leftblocks }}}

--- a/theme/edumy/templates/ccn_navbar_user.mustache
+++ b/theme/edumy/templates/ccn_navbar_user.mustache
@@ -8,7 +8,12 @@
     {{#if_user_dark_mode_icon}}
       <li class="user_setting ccn-settings-nav ccn-settings-nav-darkMode">
         <div class="dropdown">
-          <a class="notification_icon" id="ccnToggleDarkMode"><span class="{{{user_dark_mode_icon}}}"></span></a>
+          <a class="notification_icon" id="ccnToggleDarkMode" aria-label="Toggle dark mode"><span class="{{{user_dark_mode_icon}}}"></span></a>
+        </div>
+      </li>
+      <li class="user_setting ccn-settings-nav ccn-settings-nav-contrast">
+        <div class="dropdown">
+          <a class="notification_icon" id="ccnToggleContrast" aria-label="Toggle high contrast mode"><span class="fa fa-adjust"></span></a>
         </div>
       </li>
     {{/if_user_dark_mode_icon}}

--- a/theme/edumy/templates/custom_sidebar.mustache
+++ b/theme/edumy/templates/custom_sidebar.mustache
@@ -1,0 +1,8 @@
+<nav class="simple-sidebar" aria-label="Quick navigation">
+  <ul class="simple-sidebar-menu">
+    <li><a href="{{{ config.wwwroot }}}/my/" aria-label="Home"><span class="fa fa-home" aria-hidden="true"></span> <span class="label">{{#str}}home{{/str}}</span></a></li>
+    <li><a href="{{{ config.wwwroot }}}/course/index.php" aria-label="Courses"><span class="fa fa-book" aria-hidden="true"></span> <span class="label">{{#str}}courses{{/str}}</span></a></li>
+    <li><a href="{{{ config.wwwroot }}}/user/profile.php" aria-label="Profile"><span class="fa fa-user" aria-hidden="true"></span> <span class="label">{{#str}}profile{{/str}}</span></a></li>
+    <li><a href="{{{ config.wwwroot }}}/user/preferences.php" aria-label="Settings"><span class="fa fa-cog" aria-hidden="true"></span> <span class="label">{{#str}}settings{{/str}}</span></a></li>
+  </ul>
+</nav>


### PR DESCRIPTION
## Summary
- add a simple sidebar navigation to the dashboard
- allow toggling dark and high-contrast themes
- style sidebar and high-contrast mode via custom CSS
- expose theme toggles in the navbar with aria labels

## Testing
- `npm test` *(fails: Missing script "test")*

------
https://chatgpt.com/codex/tasks/task_b_6858f40608888327abe42633e87926f7