### PR TITLE
Fix phpunit workflow extension

### DIFF
--- a/.github/workflows/push.yml
+++ b/.github/workflows/push.yml
@@ -67,7 +67,7 @@ jobs:
           - os: ubuntu-22.04
             php: 8.0
             db: pgsql
-            extensions: xmlrpc-beta
+            extensions: xmlrpc
 
     steps:
       - name: Setting up DB mysql


### PR DESCRIPTION
## Summary
- fix phpunit workflow extension for PHP 8.0 by using `xmlrpc`

## Testing
- `npm install` *(fails: registry access blocked)*

------
https://chatgpt.com/codex/tasks/task_b_685903dc2fdc832790326d97868eb891